### PR TITLE
Improve notification handling for BLE temperature sensor

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This project implements a Bluetooth Low Energy (BLE) temperature sensor using th
 ## Notes ⚠️
 - [Arduino Wrapper for BTstack library does not support notifications.](https://github.com/bluekitchen/btstack/issues/551#issuecomment-1827805004) 
 - The code has been modified as a workaround to support notifications.
-- Some notifications might be dropped if the client is busy
+- Notifications are sent when temperature has changed and client is not busy.
 
 ## Hardware Requirements
 


### PR DESCRIPTION
This pull request includes multiple changes to enhance the notification mechanism in a Bluetooth Low Energy (BLE) temperature sensor project. The most important changes focus on ensuring notifications are sent only when the client is not busy and handling pending notifications.

Improvements to notification mechanism:

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L14-R14): Updated the notes to clarify that notifications are sent when the temperature changes and the client is not busy.
* [`src/main.cpp`](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R20-R21): Added new variables `notification_pending` and `pending_temperature` to manage pending notifications.
* [`src/main.cpp`](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R52-R78): Modified the `notify_client_temperature` function to request permission to send notifications when the client is busy and handle pending notifications.
* [`src/main.cpp`](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R121): Registered a global callback for HCI events and implemented a packet handler to process `ATT_EVENT_CAN_SEND_NOW` events, ensuring pending notifications are sent.
* [`src/main.cpp`](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R139-R141): Updated the `setup` function to register the HCI event handler and modified the `loop` function to check for pending notifications before sending new ones. [[1]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2R139-R141) [[2]](diffhunk://#diff-34d21af3c614ea3cee120df276c9c4ae95053830d7f1d3deaf009a4625409ad2L139-R167)